### PR TITLE
Allow omitting constructor argument to be compatible with new service configurations and PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: php
 
 php:
-    - 5.3.3
     - 5.3
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
+    - 7.1
     - hhvm
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,14 @@
 {
-    "name": "michaelmoussa/zend-psr-log",
+    "name": "legow/zend-psr-log",
     "description": "PSR3-compliant, backwards-compatible, drop-in replacement for Zend\\Log\\Logger.",
     "authors": [
         {
             "name": "Michael Moussa",
             "email": "michael.moussa@gmail.com"
+        },
+        {
+            "name": "Turcsán Ádám",
+            "email": "adam.turcsan@legow.hu"
         }
     ],
     "license": "MIT",

--- a/src/LoggerFactory.php
+++ b/src/LoggerFactory.php
@@ -27,9 +27,11 @@ class LoggerFactory implements FactoryInterface
      *
      * @param string $configKey
      */
-    public function __construct($configKey)
+    public function __construct($configKey = null)
     {
-        $this->configKey = $configKey;
+        if ($configKey !== null) {
+            $this->configKey = $configKey;
+        }
     }
 
     /**


### PR DESCRIPTION
Service config like below doesn't throw ArgumentCount error on php7 nor Warning on earlier php versions.
```php
Psr\Log\LoggerInterface::class => ZendPsrLog\LoggerFactory::class
```

Also Travis builds on php7 and 7.1 too but php5.3.3 is removed because it unnecessarily threw an error of `composer self-update` and also it's officially not supported for almost 3 years now.